### PR TITLE
Add support for kernels newer than 6.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# NOTE! Don't add files that are generated in specific
+# subdirectories here. Add them in the ".gitignore" file
+# in that subdirectory instead.
+#
+# NOTE! Please use 'git ls-files -i -c --exclude-per-directory=.gitignore'
+# command after changing this file, to see if there are
+# any tracked files which get ignored after the change.
+#
+# Normal rules (sorted alphabetically)
+#
+.*
+*.a
+*.asn1.[ch]
+*.bin
+*.bz2
+*.c.[012]*.*
+*.dt.yaml
+*.dtb
+*.dtbo
+*.dtb.S
+*.dtbo.S
+*.dwo
+*.elf
+*.gcno
+*.gz
+*.i
+*.ko
+*.lex.c
+*.ll
+*.lst
+*.lz4
+*.lzma
+*.lzo
+*.mod
+*.mod.c
+*.o
+*.o.*
+*.patch
+*.rmeta
+*.rpm
+*.rsi
+*.s
+*.so
+*.so.dbg
+*.su
+*.symtypes
+*.symversions
+*.tab.[ch]
+*.tar
+*.xz
+*.zst
+Module.symvers
+modules.order
+
+#
+# Top-level generic files
+#
+/linux
+/modules-only.symvers
+/vmlinux
+/vmlinux.32
+/vmlinux.map
+/vmlinux.symvers
+/vmlinux-gdb.py
+/vmlinuz
+/System.map
+/Module.markers
+/modules.builtin
+/modules.builtin.modinfo
+/modules.nsdeps
+
+#
+# RPM spec file (make rpm-pkg)
+#
+/kernel.spec
+/rpmbuild/
+
+#
+# Debian directory (make deb-pkg)
+#
+/debian/
+
+#
+# Snap directory (make snap-pkg)
+#
+/snap/
+
+#
+# tar directory (make tar*-pkg)
+#
+/tar-install/
+
+#
+# We don't want to ignore the following even if they are dot-files
+#
+!.clang-format
+!.cocciconfig
+!.get_maintainer.ignore
+!.gitattributes
+!.gitignore
+!.kunitconfig
+!.mailmap
+!.rustfmt.toml
+
+#
+# Generated include files
+#
+/include/config/
+/include/generated/
+/arch/*/include/generated/
+
+# stgit generated dirs
+patches-*
+
+# quilt's files
+patches
+series
+
+# ctags files
+tags
+TAGS
+
+# cscope files
+cscope.*
+ncscope.*
+
+# gnu global files
+GPATH
+GRTAGS
+GSYMS
+GTAGS
+
+# id-utils files
+ID
+
+*.orig
+*~
+\#*#
+
+#
+# Leavings from module signing
+#
+extra_certificates
+signing_key.pem
+signing_key.priv
+signing_key.x509
+x509.genkey
+
+# Kconfig presets
+/all.config
+/alldef.config
+/allmod.config
+/allno.config
+/allrandom.config
+/allyes.config
+
+# Kconfig savedefconfig output
+/defconfig
+
+# Kdevelop4
+*.kdev4
+
+# Clang's compilation database file
+/compile_commands.json
+
+# Documentation toolchain
+sphinx_*/
+
+# Rust analyzer configuration
+/rust-project.json

--- a/ch343.c
+++ b/ch343.c
@@ -797,7 +797,11 @@ static void ch343_tty_close(struct tty_struct *tty, struct file *filp)
     tty_port_close(&ch343->port, tty, filp);
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0))
+static ssize_t ch343_tty_write(struct tty_struct *tty, const unsigned char *buf, size_t count)
+#else
 static int ch343_tty_write(struct tty_struct *tty, const unsigned char *buf, int count)
+#endif
 {
     struct ch343 *ch343 = tty->driver_data;
     int stat;

--- a/ch343.c
+++ b/ch343.c
@@ -812,7 +812,11 @@ static int ch343_tty_write(struct tty_struct *tty, const unsigned char *buf, int
     if (!count)
         return 0;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0))
+    dev_vdbg(&ch343->data->dev, "%s - count %ld\n", __func__, count);
+#else
     dev_vdbg(&ch343->data->dev, "%s - count %d\n", __func__, count);
+#endif
 
     spin_lock_irqsave(&ch343->write_lock, flags);
     wbn = ch343_wb_alloc(ch343);


### PR DESCRIPTION
The signature of the `write` member in struct `tty_operations` has changed since kernel 6.6. See [this](https://github.com/torvalds/linux/blob/v6.6/include/linux/tty_driver.h#L75).

This patch adds the conditional signature for the `ch343_tty_write` function.

Tested on 6.11.6-arch1-1 but should work for kernels newer than 6.6.

@FirstLoveLife 