### PR TITLE
Point to the right unaligned.h

### DIFF
--- a/ch343.c
+++ b/ch343.c
@@ -30,7 +30,11 @@
 #undef VERBOSE_DEBUG
 
 #include <asm/byteorder.h>
+#if __has_include(<asm/unaligned.h>)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 #include <linux/errno.h>
 #include <linux/idr.h>
 #include <linux/init.h>


### PR DESCRIPTION
The `unaligned.h` is moved to `include/linux` in recent kernel releases. Use __has_include to detect the location of the header file instead of using linux kernel versions as different distributions may vary.

e.g. The change is in 6.12.rc2 in the official kernel but 6.12.1 in the archlinux kernel.